### PR TITLE
fix: Correct audio source handling for Supabase storage

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { createBrowserClient } from '@supabase/ssr';
+import { getAudioSource } from '@/utils/audio';
 
 interface Sound {
   id: string;
@@ -184,7 +185,7 @@ export default function AdminPage() {
                     Tags: {Array.isArray(sound.tags) ? sound.tags.join(', ') : 'No tags'}
                   </p>
                   <audio controls className="mt-2">
-                    <source src={sound.url} type="audio/mpeg" />
+                    <source src={getAudioSource(sound.url)} type="audio/mpeg" />
                     Your browser does not support the audio element.
                   </audio>
                 </div>

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { createBrowserClient } from '@supabase/ssr';
 import { useRouter } from 'next/navigation';
 import { Search, Plus, Trash2 } from 'lucide-react';
+import { getAudioSource } from '@/utils/audio';
 
 interface Sound {
   id: string;
@@ -174,7 +175,7 @@ export default function LibraryPage() {
                   controls 
                   className="w-full [&::-webkit-media-controls-panel]:bg-gray-50"
                 >
-                  <source src={sound.url} type="audio/mpeg" />
+                  <source src={getAudioSource(sound.url)} type="audio/mpeg" />
                   Your browser does not support the audio element.
                 </audio>
               </div>

--- a/src/components/SearchBox.tsx
+++ b/src/components/SearchBox.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { createBrowserClient } from '@supabase/ssr';
 import { toast } from 'react-hot-toast';
+import { getAudioSource } from '@/utils/audio';
 
 interface Sound {
   id: string;
@@ -221,7 +222,7 @@ export default function SearchBox() {
                 controls 
                 className="w-full [&::-webkit-media-controls-panel]:bg-[#3C3C3E] [&::-webkit-media-controls-current-time-display]:text-white [&::-webkit-media-controls-time-remaining-display]:text-white"
               >
-                <source src={sound.url} type="audio/mpeg" />
+                <source src={getAudioSource(sound.url)} type="audio/mpeg" />
                 Your browser does not support the audio element.
               </audio>
             </div>

--- a/src/utils/audio.ts
+++ b/src/utils/audio.ts
@@ -1,0 +1,9 @@
+export function getAudioSource(url: string): string {
+  // Check if the URL is a full URL (starts with http:// or https://)
+  if (url.startsWith('http://') || url.startsWith('https://')) {
+    return url;
+  }
+  
+  // If it's a file path, prepend the base URL with the correct bucket name 'audio'
+  return `${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/audio/${url}`;
+} 


### PR DESCRIPTION
This PR fixes the audio source handling to properly work with both URL and file path sources, specifically addressing the Supabase storage bucket configuration.

Changes:
- Created `getAudioSource` utility function in `src/utils/audio.ts`
- Updated components to use the correct Supabase 'audio' bucket
- Fixed audio playback for files stored in Supabase storage

The utility function now correctly:
- Handles full URLs (http://, https://)
- Properly formats file paths to use the Supabase 'audio' bucket
- Ensures consistent audio playback across the application